### PR TITLE
Fix build_ui on Windows.

### DIFF
--- a/distutils_ui/build_ui.py
+++ b/distutils_ui/build_ui.py
@@ -78,7 +78,7 @@ class build_tool(Command):
         self.chdir = self.parse_arg('chdir', self.chdir or '')
         # subprocess environment: run tools in posix locale
         self.env = dict(os.environ)
-        self.env['LANG'] = b'C'
+        self.env['LANG'] = 'C'
 
     def run(self):
         self.debug('%s.run', self.__class__.__name__)


### PR DESCRIPTION
The environment passed to subprocesses on Windows may only
contain str, not bytes.